### PR TITLE
fix: use which npm package for windows compatibility

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -257,7 +257,7 @@ class LinterESLintNode {
           projectPath
         });
       } catch (err) {
-        if (err.name = 'InvalidWorkerError') {
+        if (err.name === 'InvalidWorkerError') {
           // Worker script can't run. Fill in some dummy values here.
           response = {
             eslintPath: '(unknown)',

--- a/lib/node-path-tester.js
+++ b/lib/node-path-tester.js
@@ -1,6 +1,7 @@
 'use babel';
 import { existsSync } from 'fs';
 import { exec, execSync } from 'child_process';
+import which from 'which';
 
 const NodePathTester = {
   _timeout: null,
@@ -35,11 +36,11 @@ const NodePathTester = {
   resolve (bin) {
     if (bin.startsWith('/') && existsSync(bin) ) { return Promise.resolve(bin); }
     return new Promise((resolve, reject) => {
-      exec(`which ${bin}`, (err, stdout) => {
+      which(bin, (err, resolvedPath) => {
         if (err) {
           reject(err);
         } else {
-          resolve(stdout);
+          resolve(resolvedPath);
         }
       });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "atom-package-deps": "^8.0.0",
         "compare-versions": "^4.1.3",
         "eslint": "^8.9.0",
-        "ndjson": "^2.0.0"
+        "ndjson": "^2.0.0",
+        "which": "^2.0.2"
       },
       "devDependencies": {
         "eslint-plugin-import": "^2.25.4",

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "atom-package-deps": "^8.0.0",
     "compare-versions": "^4.1.3",
     "eslint": "^8.9.0",
-    "ndjson": "^2.0.0"
+    "ndjson": "^2.0.0",
+    "which": "^2.0.2"
   }
 }


### PR DESCRIPTION
`Linter Eslint Node: Debug` fails on windows since `which` is not a command.

The [`which`](https://www.npmjs.com/package/which) npm package is compatible with all OSes as well as handling some other edge cases.

I also fixed a little bug in `main.js`