### PR TITLE
Add NodePathTester tests

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -91,7 +91,7 @@ const Config = {
     if (!configChanged(newConfig, this._currentConfig)) { return; }
     if (this._currentConfig) {
       for (let handler of this.handlers) {
-        handler(newConfig, this._currentConfig || {});
+        handler(newConfig, this._currentConfig);
       }
     }
     this._currentConfig = newConfig;

--- a/lib/job-manager.js
+++ b/lib/job-manager.js
@@ -28,63 +28,97 @@ class InvalidWorkerError extends Error {
   }
 }
 
+// A class that handles creating, maintaining, and communicating with the
+// worker that we spawn to perform linting.
 class JobManager {
   constructor () {
     this.handlersForJobs = new Map();
     this.worker = null;
     this.workerPath = Path.join(__dirname, 'worker.js');
-
-    this.createWorker();
   }
 
   dispose () {
     this.killWorker();
+    this.worker = null;
+    this._workerPromise = null;
+    this.handlersForJobs = null;
   }
 
+  // Resolves when the worker is spawned and ready to process messages. Rejects
+  // if the worker errors during startup.
   createWorker () {
-    let nodeBin = Config.get('nodeBin');
-    console.debug('JobManager creating worker at:', nodeBin, this.workerPath);
-    this.killWorker();
-
-    // We should not try to start the worker without testing the value we have
-    // for `nodeBin`.
-    //
-    // When the setting is changed after initialization, we test it
-    // asynchronously before calling `createWorker` again. In those cases,
-    // `testSync` just looks up the result of that test so we don't duplicate
-    // effort.
-    //
-    // But on startup, we don't want to defer creation of this worker while we
-    // perform an async test of `nodeBin`. So in that one scenario, `testSync`
-    // will do an `execSync` on this value to perform a sanity check. Like the
-    // async version, we remember this result, so further calls to `testSync`
-    // with the same value won't block while we run a shell command.
-    //
-    // TODO: See if there's a way to use the async test logic on startup
-    // without putting us in async/promise hell.
-    if (!NodePathTester.testSync(nodeBin)) {
-      console.error('Invalid nodeBin!');
-      this.worker = false;
-      return false;
+    // When reloading an existing project with X tabs open, this method will be
+    // called X times in a very short span of time. They all need to wait for
+    // the _same_ worker to spawn instead of each trying to spawn their own.
+    if (this._workerPromise) {
+      // The worker is already in the process of being created.
+      return this._workerPromise;
     }
 
-    this.worker = spawn(nodeBin, [this.workerPath]);
+    let nodeBin = Config.get('nodeBin');
+    console.debug('JobManager creating worker at:', nodeBin);
+    this.killWorker();
 
-    this.worker.stdout
-      .pipe(ndjson.parse())
-      .on('data', this.receiveMessage.bind(this));
+    // We choose to do a sync test here because this method is much easier to
+    // reason about without an `await` keyword introducing side effects.
+    //
+    // In practice, this will result in only one brief call to `execSync` when
+    // a project window is created/reloaded; subsequent calls with the same
+    // `nodeBin` argument will reuse the earlier value.
+    //
+    // When `nodeBin` is changed in the middle of a session, we validate the
+    // new value asynchronously _before_ we reach this method, and `testSync`
+    // merely looks up the async validation's result.
+    let isValid = NodePathTester.testSync(nodeBin);
+    if (!isValid) {
+      this.worker = false;
+      throw new InvalidWorkerError();
+    }
 
-    // Even unanticipated runtime errors will get sent as newline-delimited
-    // JSON.
-    this.worker.stderr
-      .pipe(ndjson.parse())
-      .on('data', this.receiveError.bind(this));
+    let promise = new Promise((resolve, reject) => {
+      this.worker = spawn(nodeBin, [this.workerPath]);
 
-    this.worker.on('close', () => {
-      if (this.worker.killed === false) {
-        this.createWorker();
-      }
+      // Reject this promise if the worker fails to spawn.
+      this.worker.on('error', reject);
+
+      this.worker.stdout
+        .pipe(ndjson.parse())
+        .on('data', (obj) => {
+          // We could listen for the `spawn` event to know when the worker is
+          // ready, but that event wasn't added until Node v14.17. Instead,
+          // we'll just have the worker emit a `ready` message.
+          if (obj.type === 'ready') {
+            resolve();
+          } else {
+            this.receiveMessage(obj);
+          }
+        });
+
+      // Even unanticipated runtime errors will get sent as newline-delimited
+      // JSON.
+      this.worker.stderr
+        .pipe(ndjson.parse())
+        .on('data', this.receiveError.bind(this));
+
+      this.worker.on('close', () => {
+        if (this.worker.killed === false) {
+          this.createWorker();
+        }
+      });
     });
+
+    this._workerPromise = promise;
+    this._workerPromise
+      .then(() => this._workerPromise = null)
+      .catch(() => this._workerPromise = null);
+
+    return promise;
+  }
+
+  suspend () {
+    console.warn('Suspending worker');
+    this.killWorker();
+    this.worker = null;
   }
 
   killWorker () {
@@ -136,20 +170,14 @@ class JobManager {
   }
 
   async send (bundle) {
+    if (!this.worker) {
+      console.warn('Creating worker');
+      await this.createWorker();
+    }
+
     let key = generateKey();
     bundle.key = key;
     console.debug('JobManager#send:', bundle);
-    try {
-      this.ensureWorker();
-    } catch (err) {
-      if (this.worker === false) {
-        // `false` means we intentionally refused to create a worker because
-        // `nodeBin` was invalid.
-        throw new InvalidWorkerError();
-      } else {
-        throw err;
-      }
-    }
 
     return new Promise((resolve, reject) => {
       this.handlersForJobs.set(key, [resolve, reject]);

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,7 +4,6 @@ import { CompositeDisposable } from 'atom';
 // eslint-disable-next-line import/no-unresolved
 import { shell } from 'electron';
 import Path from 'path';
-import { diff } from 'deep-object-diff';
 
 import console from './console';
 import Config from './config';
@@ -113,7 +112,7 @@ export default {
       Config.onConfigDidChange(
         (config, prevConfig) => {
           this.inactive = false;
-          console.debug('Config changed:', config, prevConfig, diff(prevConfig, config));
+          console.debug('Config changed:', config, prevConfig);
           if (helpers.configShouldInvalidateWorkerCache(config, prevConfig)) {
             this.clearESLintCache();
           }

--- a/lib/main.js
+++ b/lib/main.js
@@ -63,15 +63,23 @@ export default {
     this.workerPath = Path.join(__dirname, 'worker.js');
     this.jobManager = new JobManager();
 
-    // Inactive is the mode we enter when (a) there is no ESLint for this
-    // project, or (b) there is a too-old ESLint, or (c) there is a v7 ESLint
-    // that we're letting the legacy package handle. We don't bother to send
-    // jobs to the worker in this mode; no use making the round-trip. But we
-    // will wake up if literally anything changes about the project that might
-    // invalidate our assumptions.
+    // “Inactive” is the mode we enter when we think a project won’t be doing
+    // much, or any, linting. Examples include (a) no ESLint in this project,
+    // (b) too-old ESLint in this project, (c) v7 ESLint when we’re deferring
+    // to the legacy package. Option A will be the most common, as it would
+    // also apply to all non-JavaScript projects, for which it’s silly and
+    // wasteful to keep a worker process around.
     //
-    // TODO: Consider killing the worker in inactive mode and restarting it
-    // if we leave?
+    // If we see evidence of any of these situations, we should put ourselves
+    // to sleep via `this.sleep`. This kills our worker process, and it also
+    // means that we’ll return empty results for linting requests without an
+    // unnecessary round-trip to the worker.
+    //
+    // This isn’t a problem because we can wake whenever we want, and the job
+    // manager will create a new worker the next time we send it a job. So we
+    // should wake whenever anything changes about the project that might
+    // invalidate our assumptions. We’ll also wake when the user explicitly
+    // triggers the “Fix File” or “Debug” commands.
     this.inactive = false;
 
     // Keep track of whether the user has seen certain notifications. Absent
@@ -103,7 +111,7 @@ export default {
 
       // Scan for new .linter-eslint config files when project paths change.
       atom.project.onDidChangePaths(() => {
-        this.inactive = false;
+        this.wake();
         Config.rescan();
       }),
 
@@ -111,7 +119,7 @@ export default {
       // base package settings.
       Config.onConfigDidChange(
         (config, prevConfig) => {
-          this.inactive = false;
+          this.wake();
           console.debug('Config changed:', config, prevConfig);
           if (helpers.configShouldInvalidateWorkerCache(config, prevConfig)) {
             this.clearESLintCache();
@@ -128,10 +136,10 @@ export default {
               .test(config.nodeBin)
               .then((version) => {
                 console.log(`Switched Node to version:`, version);
-                this.jobManager.createWorker();
+                this.jobManager.suspend();
               })
               .catch(() => {
-                this.inactive = true;
+                this.sleep();
                 this.notifyAboutInvalidNodeBin();
               });
           }
@@ -140,10 +148,16 @@ export default {
 
       atom.commands.add('atom-text-editor', {
         'linter-eslint-node:fix-file': async () => {
+          let wasInactive = this.inactive;
+          this.wake();
           await this.fixJob();
+          if (wasInactive) { this.sleep(); }
         },
         'linter-eslint-node:debug': async () => {
+          let wasInactive = this.inactive;
+          this.wake();
           await this.debugJob();
+          if (wasInactive) { this.sleep(); }
         }
       }),
 
@@ -155,13 +169,14 @@ export default {
           if (event.path.includes('node_modules')) { return false; }
 
           if (eventInvolvesFile(event, '.linter-eslint')) {
-            this.inactive = false;
+            this.wake();
             Config.rescan();
           }
           // Instances of `ESLint` cache whatever configuration details were
           // present at instantiation time. If any config changes, we can't
           // re-use old instances.
           if (eventInvolvesFile(event, '.eslintignore') || eventInvolvesEslintrc(event)) {
+            this.wake();
             this.clearESLintCache();
           }
         }
@@ -200,6 +215,16 @@ export default {
     this.subscriptions.dispose();
     this.jobManager.dispose();
     Config.dispose();
+  },
+
+  sleep () {
+    this.inactive = true;
+    this.jobManager.suspend();
+  },
+
+  wake () {
+    // No need to start the worker; it will restart next time we lint.
+    this.inactive = false;
   },
 
   notifyAboutInvalidNodeBin () {
@@ -265,7 +290,8 @@ export default {
             eslintPath: '(unknown)',
             eslintVersion: '(unknown)',
             isIncompatible: false,
-            isOverlap: false
+            isOverlap: false,
+            workerPid: null
           };
         } else {
           throw err;
@@ -291,7 +317,8 @@ export default {
         platform: process.platform,
         editorScopes,
         nodePath,
-        nodeVersion
+        workerPid: response.workerPid,
+        nodeVersion: nodeVersion.toString('utf-8').replace(/\n/, '')
       };
 
       if (response.eslintPath) {
@@ -301,6 +328,7 @@ export default {
       }
     } catch (error) {
       atom.notifications.addError(`${error}`, { dismissable: true });
+      return;
     }
 
     let whichPackageWillLint;
@@ -315,8 +343,9 @@ export default {
     let debugMessage = [
       `Atom version: ${debug.atomVersion}`,
       `linter-eslint-node version: ${debug.packageVersion}`,
-      `Node version: ${debug.nodeVersion}`,
-      `Node path: ${debug.nodePath}`,
+      `Worker using Node at path: ${debug.nodePath}`,
+      `Worker Node version: ${debug.nodeVersion}`,
+      `Worker PID: ${debug.workerPid}`,
       `ESLint version: ${debug.eslintVersion}`,
       `ESLint location: ${debug.eslintPath}`,
       `Linting in this project performed by: ${whichPackageWillLint}`,
@@ -361,7 +390,7 @@ export default {
 
     // If we're in inactive mode and we get this far, it's because the user
     // explicitly ran the `Fix Job` command, so we should wake up.
-    this.inactive = false;
+    this.wake();
 
     if (textEditor.isModified()) {
       atom.notifications.addError(
@@ -411,13 +440,13 @@ export default {
       // this session), we should do nothing here so that an invalid worker
       // behaves as though no linter is present at all.
       this.notifyAboutInvalidNodeBin();
-      this.inactive = true;
+      this.sleep();
       return null;
     }
 
     if (err.type && err.type === 'config-not-found') {
       if (Config.get('disabling.disableWhenNoEslintConfig')) {
-        this.inactive = true;
+        this.sleep();
         return [];
       }
       if (type === 'fix') {
@@ -453,14 +482,14 @@ export default {
 
     if (err.type && err.type === 'no-project') {
       // No project means nowhere to look for an `.eslintrc`.
-      this.inactive = true;
+      this.sleep();
       return null;
     }
 
     if (err.type && err.type === 'version-overlap') {
       // This is an easy one: we don't need to lint this file because
       // `linter-eslint` is present and can handle it. Do nothing.
-      this.inactive = true;
+      this.sleep();
       return null;
     }
 
@@ -473,7 +502,7 @@ export default {
       // this window has been open; no use spamming it on every lint attempt.
       let linterEslintPresent = this.isLegacyPackagePresent();
       let didNotify = this.notified.incompatibleVersion;
-      this.inactive = true;
+      this.sleep();
       if (linterEslintPresent || didNotify || !Config.get('warnAboutOldEslint')) {
         return null;
       } else {
@@ -557,24 +586,24 @@ export default {
           });
 
           if (text !== textEditor.getText()) {
-            // The editor contents have changed since we requested this lint job.
-            // We can't be certain that the linter results aren't stale, so we'll
-            // return `null` to signal to Linter that it shouldn't update the
-            // saved results.
+            // The editor contents have changed since we requested this lint
+            // job. We can't be certain that the linter results aren't stale,
+            // so we'll return `null` to signal to Linter that it shouldn't
+            // update the saved results.
             return null;
           }
 
           if (response === null) {
             // An explicit `null` response from the worker means that it has
-            // failed to find ESLint in the load path. This will happen if Node,
-            // running from the project root, fails to find any version of
-            // `eslint` in the load path, whether local or global.
+            // failed to find ESLint in the load path. This will happen if
+            // Node, running from the project root, fails to find any version
+            // of `eslint` in the load path, whether local or global.
             //
             // TODO: In these cases, a `null` response will produce the same
             // result as if this linter weren't installed at all. If we wanted
             // some of these scenarios to produce notifications to the user (so
-            // they could make corrections), we'd have to distinguish those cases
-            // somehow.
+            // they could make corrections), we'd have to distinguish those
+            // cases somehow.
             return response;
           }
 
@@ -588,8 +617,8 @@ export default {
             if (result.fix) {
               if (willAutoFix) {
                 // Ignore this violation altogether; a separate fix-on-save job
-                // is about to fix it. Otherwise the panel might appear for just
-                // a fraction of a second before disappearing.
+                // is about to fix it. Otherwise the panel might appear for
+                // just a fraction of a second before disappearing.
                 continue;
               }
               result.solutions = helpers.solutionsForFix(result.fix, textBuffer);

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,6 +4,7 @@ import { CompositeDisposable } from 'atom';
 // eslint-disable-next-line import/no-unresolved
 import { shell } from 'electron';
 import Path from 'path';
+import { diff } from 'deep-object-diff';
 
 import console from './console';
 import Config from './config';
@@ -47,6 +48,7 @@ function eventInvolvesEslintrc (event) {
 export default {
 
   shouldAutoFix (textEditor) {
+    if (this.inactive) { return false; }
     if (textEditor.isModified()) { return false; }
     if (!Config.get('autofix.fixOnSave')) { return false; }
     if (!helpers.hasValidScope(textEditor, this.scopes)) { return false; }
@@ -58,9 +60,20 @@ export default {
   },
 
   async activate () {
-    Config.initialize(atom.project.getPaths()[0]);
+    Config.initialize();
     this.workerPath = Path.join(__dirname, 'worker.js');
     this.jobManager = new JobManager();
+
+    // Inactive is the mode we enter when (a) there is no ESLint for this
+    // project, or (b) there is a too-old ESLint, or (c) there is a v7 ESLint
+    // that we're letting the legacy package handle. We don't bother to send
+    // jobs to the worker in this mode; no use making the round-trip. But we
+    // will wake up if literally anything changes about the project that might
+    // invalidate our assumptions.
+    //
+    // TODO: Consider killing the worker in inactive mode and restarting it
+    // if we leave?
+    this.inactive = false;
 
     // Keep track of whether the user has seen certain notifications. Absent
     // any user-initiated changes, they should see each of these no more than
@@ -90,13 +103,17 @@ export default {
       ),
 
       // Scan for new .linter-eslint config files when project paths change.
-      atom.project.onDidChangePaths(() => Config.rescan()),
+      atom.project.onDidChangePaths(() => {
+        this.inactive = false;
+        Config.rescan();
+      }),
 
       // React to changes that happen either in a .linter-eslint file or the
       // base package settings.
       Config.onConfigDidChange(
         (config, prevConfig) => {
-          console.debug('Config changed:', config, prevConfig);
+          this.inactive = false;
+          console.debug('Config changed:', config, prevConfig, diff(prevConfig, config));
           if (helpers.configShouldInvalidateWorkerCache(config, prevConfig)) {
             this.clearESLintCache();
           }
@@ -115,6 +132,7 @@ export default {
                 this.jobManager.createWorker();
               })
               .catch(() => {
+                this.inactive = true;
                 this.notifyAboutInvalidNodeBin();
               });
           }
@@ -138,19 +156,13 @@ export default {
           if (event.path.includes('node_modules')) { return false; }
 
           if (eventInvolvesFile(event, '.linter-eslint')) {
+            this.inactive = false;
             Config.rescan();
           }
-          // Any creation, deletion, renaming, or modification of an
-          // `.eslintignore` file anywhere in this project will affect which
-          // files this linter should ignore, and will confuse old instances of
-          // `ESLint` inside the worker script because they seem to cache too
-          // aggressively. So in these cases we've got to clear our cache and
-          // force new `ESLint` instances to be created.
-          if (eventInvolvesFile(event, '.eslintignore')) {
-            this.clearESLintCache();
-          }
-
-          if (eventInvolvesEslintrc(event)) {
+          // Instances of `ESLint` cache whatever configuration details were
+          // present at instantiation time. If any config changes, we can't
+          // re-use old instances.
+          if (eventInvolvesFile(event, '.eslintignore') || eventInvolvesEslintrc(event)) {
             this.clearESLintCache();
           }
         }
@@ -205,13 +217,8 @@ export default {
     this.notified.invalidNodeBin = true;
   },
 
-  // We need to tell the worker to clear its cache when
-  // - any .eslintignore file is changed;
-  // - certain options are changed that must be declared at `ESLint`
-  //   instantiation time.
-  //
   clearESLintCache () {
-    console.warn('Telling the worker to clear its cache!');
+    console.debug('Telling the worker to clear its cache');
     this.jobManager.send({ type: 'clear-cache' });
   },
 
@@ -309,8 +316,8 @@ export default {
     let debugMessage = [
       `Atom version: ${debug.atomVersion}`,
       `linter-eslint-node version: ${debug.packageVersion}`,
-      `Node path: ${debug.nodePath}`,
       `Node version: ${debug.nodeVersion}`,
+      `Node path: ${debug.nodePath}`,
       `ESLint version: ${debug.eslintVersion}`,
       `ESLint location: ${debug.eslintPath}`,
       `Linting in this project performed by: ${whichPackageWillLint}`,
@@ -324,9 +331,19 @@ export default {
       'linter-eslint-node debug information',
       {
         detail: debugMessage.join('\n'),
-        dismissable: true
+        dismissable: true,
+        buttons: [
+          {
+            text: 'Copy',
+            onDidClick () {
+              atom.clipboard.write(debugMessage.join('\n'));
+            }
+          }
+        ]
       }
     );
+
+    return debug;
   },
 
   // Here we're operating entirely outside the purview of the `linter` package.
@@ -342,6 +359,10 @@ export default {
     if (!textEditor || !atom.workspace.isTextEditor(textEditor)) {
       return;
     }
+
+    // If we're in inactive mode and we get this far, it's because the user
+    // explicitly ran the `Fix Job` command, so we should wake up.
+    this.inactive = false;
 
     if (textEditor.isModified()) {
       atom.notifications.addError(
@@ -391,11 +412,13 @@ export default {
       // this session), we should do nothing here so that an invalid worker
       // behaves as though no linter is present at all.
       this.notifyAboutInvalidNodeBin();
+      this.inactive = true;
       return null;
     }
 
     if (err.type && err.type === 'config-not-found') {
       if (Config.get('disabling.disableWhenNoEslintConfig')) {
+        this.inactive = true;
         return [];
       }
       if (type === 'fix') {
@@ -431,12 +454,14 @@ export default {
 
     if (err.type && err.type === 'no-project') {
       // No project means nowhere to look for an `.eslintrc`.
+      this.inactive = true;
       return null;
     }
 
     if (err.type && err.type === 'version-overlap') {
       // This is an easy one: we don't need to lint this file because
       // `linter-eslint` is present and can handle it. Do nothing.
+      this.inactive = true;
       return null;
     }
 
@@ -449,6 +474,7 @@ export default {
       // this window has been open; no use spamming it on every lint attempt.
       let linterEslintPresent = this.isLegacyPackagePresent();
       let didNotify = this.notified.incompatibleVersion;
+      this.inactive = true;
       if (linterEslintPresent || didNotify || !Config.get('warnAboutOldEslint')) {
         return null;
       } else {
@@ -471,17 +497,19 @@ export default {
           }
         );
         this.notified.incompatibleVersion = true;
+        return null;
       }
-    } else {
-      atom.notifications.addError(
-        `linter-eslint-node Error`,
-        {
-          description: err.error,
-          dismissable: true
-        }
-      );
-      return null;
     }
+
+    // Unknown/unhandled error from the worker.
+    atom.notifications.addError(
+      `linter-eslint-node Error`,
+      {
+        description: err.error,
+        dismissable: true
+      }
+    );
+    return null;
   },
 
   provideLinter () {
@@ -493,6 +521,10 @@ export default {
       lint: async (textEditor) => {
         console.warn('Linting', textEditor);
         if (!atom.workspace.isTextEditor(textEditor)) {
+          return null;
+        }
+        if (this.inactive) {
+          console.debug('Inactive; skipping lint');
           return null;
         }
         const filePath = textEditor.getPath();

--- a/lib/node-path-tester.js
+++ b/lib/node-path-tester.js
@@ -5,6 +5,7 @@ import which from 'which';
 
 const NodePathTester = {
   _knownGoodValues: new Map(),
+  _pendingTests: new Map(),
 
   // Tries to discern the absolute path to the user's `node` binary.
   // TODO: Handle relative paths, not just the bare value `node`.
@@ -21,6 +22,7 @@ const NodePathTester = {
     }
     try {
       let stdout = execSync(`${bin} --version`);
+      this._knownGoodValues.set(bin, stdout);
       return stdout;
     } catch (err) {
       return false;
@@ -31,12 +33,15 @@ const NodePathTester = {
     if (this._knownGoodValues.has(bin)) {
       return Promise.resolve(this._knownGoodValues.get(bin));
     }
+    if (this._pendingTests.has(bin)) {
+      return this._pendingTests.get(bin);
+    }
     // Assume it's valid until we know otherwise.
     this.valid = true;
-    return new Promise((resolve, reject) => {
+    let promise = new Promise((resolve, reject) => {
       exec(`${bin} --version`, (err, stdout) => {
+        this._pendingTests.delete(bin);
         if (err) {
-          console.log('error!');
           this.valid = false;
           reject(err);
         } else {
@@ -45,6 +50,8 @@ const NodePathTester = {
         }
       });
     });
+    this._pendingTests.set(bin, promise);
+    return promise;
   }
 };
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -116,20 +116,20 @@ function clearESLintCache () {
   }
 }
 
-function resolveESLint (filePath) {
-  try {
-    return createRequire(filePath).resolve('eslint');
-  } catch (e) {
-    return createRequire(__dirname).resolve('eslint');
-  }
-}
-
 let builtInEslintPath;
 function resolveBuiltInESLint () {
   if (!builtInEslintPath) {
     builtInEslintPath = createRequire(__dirname).resolve('eslint');
   }
   return builtInEslintPath;
+}
+
+function resolveESLint (filePath) {
+  try {
+    return createRequire(filePath).resolve('eslint');
+  } catch (e) {
+    return resolveBuiltInESLint();
+  }
 }
 
 function getESLint (filePath, config, { legacyPackagePresent, projectPath }) {
@@ -177,7 +177,7 @@ function getESLint (filePath, config, { legacyPackagePresent, projectPath }) {
 
     // Older versions of ESLint won't have this API.
     if (ESLint) {
-      let commonOptions = buildCommonConstructorOptions(config, projectPath || resolveDir);
+      let commonOptions = buildCommonConstructorOptions(config, resolveDir);
 
       const eslintLint = new ESLint({ ...commonOptions, fix: false });
       const eslintFix = new ESLint({ ...commonOptions });

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -18,10 +18,12 @@ const ESLINT_CACHE = new Map();
 
 // TODO: There must be some cases where this logic is too naive, right?
 function descendsFrom (filePath, projectPath) {
+  if (typeof filePath !== 'string') { return false; }
   return filePath.startsWith(projectPath.endsWith(Path.sep) ? projectPath : `${projectPath}${Path.sep}`);
 }
 
 function findCwd (filePath, projectPath) {
+  if (typeof filePath !== 'string') { return projectPath; }
   if (!projectPath || !descendsFrom(filePath, projectPath)) {
     return Path.dirname(filePath);
   }
@@ -132,7 +134,7 @@ function resolveESLint (filePath) {
   }
 }
 
-function getESLint (filePath, config, { legacyPackagePresent, projectPath }) {
+function getESLint (filePath, config, { isDebug, legacyPackagePresent, projectPath }) {
   let { advanced: { useCache } } = config;
   // If two files share a `cwd`, we can reuse any `ESLint` instance that was
   // created for one to lint the other. The `cwd` is almost always the project
@@ -190,14 +192,16 @@ function getESLint (filePath, config, { legacyPackagePresent, projectPath }) {
 
   let cached = ESLINT_CACHE.get(resolveDir);
 
-  if (compareVersions(cached.eslintVersion, MINIMUM_ESLINT_VERSION) < 1) {
-    // Unsupported version.
-    throw new IncompatibleVersionError(cached.eslintVersion);
-  } else if ((compareVersions(cached.eslintVersion, '8.0.0') < 1) && legacyPackagePresent) {
-    // We're dealing with version 7 of ESLint. The legacy `linter-eslint`
-    // package is present and capable of linting with this version, so we
-    // should halt instead of trying to lint everything twice.
-    throw new VersionOverlapError(cached.eslintVersion);
+  if (!isDebug) {
+    if (compareVersions(cached.eslintVersion, MINIMUM_ESLINT_VERSION) < 1) {
+      // Unsupported version.
+      throw new IncompatibleVersionError(cached.eslintVersion);
+    } else if ((compareVersions(cached.eslintVersion, '8.0.0') < 1) && legacyPackagePresent) {
+      // We're dealing with version 7 of ESLint. The legacy `linter-eslint`
+      // package is present and capable of linting with this version, so we
+      // should halt instead of trying to lint everything twice.
+      throw new VersionOverlapError(cached.eslintVersion);
+    }
   }
 
   return cached;
@@ -330,7 +334,11 @@ async function processMessage (bundle) {
 
   let eslint;
   try {
-    eslint = getESLint(filePath, config, { legacyPackagePresent, projectPath });
+    eslint = getESLint(filePath, config, {
+      isDebug: type === 'debug',
+      legacyPackagePresent,
+      projectPath
+    });
   } catch (err) {
     if (err instanceof IncompatibleVersionError) {
       emit({
@@ -351,6 +359,7 @@ async function processMessage (bundle) {
       emit({
         key,
         error: `Can't find an ESLint for file: ${filePath}`,
+        stack: err.stack,
         type: 'unknown'
       });
     }
@@ -368,7 +377,8 @@ async function processMessage (bundle) {
       eslintVersion,
       isIncompatible,
       isOverlap,
-      isBuiltIn
+      isBuiltIn,
+      workerPid: process.pid
     });
     return;
   }
@@ -412,7 +422,7 @@ async function processMessage (bundle) {
 }
 
 if (require.main === module) {
-  process.stdin.pipe(ndjson.parse()).on('data', processMessage);
+  process.stdin.pipe(ndjson.parse({ strict: false })).on('data', processMessage);
   process.stdin.resume();
   process.on('uncaughtException', (error) => {
     error.uncaught = true;
@@ -421,4 +431,6 @@ if (require.main === module) {
       JSON.stringify(error, Object.getOwnPropertyNames(error))
     );
   });
+  process.title = `node (linter-eslint-node worker ${process.pid})`;
+  emit({ type: 'ready' });
 }

--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -20,7 +20,6 @@ const paths = {
 };
 
 
-// Skipping until we can sort out why these are so flaky in CI.
 describe('Config module', () => {
 
   beforeEach(async () => {

--- a/spec/node-path-tester-spec.js
+++ b/spec/node-path-tester-spec.js
@@ -1,4 +1,5 @@
 'use babel';
+/* global pass */
 
 import NodePathTester from '../lib/node-path-tester';
 
@@ -26,10 +27,9 @@ describe('Node path tester', () => {
       expect(await NodePathTester.test('node')).not.toBe(false);
       try {
         await NodePathTester.test('fdsfljksdafd');
-        // If we get this far, fail the test
-        expect(false).toBe(true);
+        fail();
       } catch (err) {
-        expect(err instanceof Error).toBe(true);
+        pass();
       }
     });
   });

--- a/spec/node-path-tester-spec.js
+++ b/spec/node-path-tester-spec.js
@@ -1,0 +1,36 @@
+'use babel';
+
+import NodePathTester from '../lib/node-path-tester';
+
+describe('Node path tester', () => {
+
+  beforeEach(async () => {
+    atom.config.set('linter-eslint-node.nodeBin', 'node');
+
+    atom.packages.triggerDeferredActivationHooks();
+    atom.packages.triggerActivationHook('core:loaded-shell-environment');
+
+    await atom.packages.activatePackage('language-javascript');
+    await atom.packages.activatePackage('linter-eslint-node');
+  });
+
+  describe('testSync', () => {
+    it('tests the location of nodeBin synchronously', () => {
+      expect(NodePathTester.testSync('node')).not.toBe(false);
+      expect(NodePathTester.testSync('fdsfljksdafd')).toBe(false);
+    });
+  });
+
+  describe('test', () => {
+    it('tests the location of nodeBin asynchronously', async () => {
+      expect(await NodePathTester.test('node')).not.toBe(false);
+      try {
+        await NodePathTester.test('fdsfljksdafd');
+        // If we get this far, fail the test
+        expect(false).toBe(true);
+      } catch (err) {
+        expect(err instanceof Error).toBe(true);
+      }
+    });
+  });
+});

--- a/spec/runner.js
+++ b/spec/runner.js
@@ -16,7 +16,21 @@ function setDefaultSettings(namespace, settings) {
 module.exports = createRunner({
   testPackages: ['linter', 'linter-ui-default'],
   timeReporter: true,
-  specHelper: true
+  specHelper: {
+    atom: true,
+    attachToDom: true,
+    ci: true,
+    customMatchers: true,
+    jasmineFocused: true,
+    jasmineJson: true,
+    jasminePass: true,
+    jasmineTagged: true,
+    mockClock: true,
+    mockLocalStorage: true,
+    profile: true,
+    set: true,
+    unspy: true
+  }
 },
 () => {
   beforeEach(() => {


### PR DESCRIPTION
I've also got an interest in reducing how much this package does in projects without ESLint installed, or in windows that aren't even JavaScript projects. Ideally I'd like to kill the worker once it's clear it's not needed, but for now all I'm interested in doing is not sending a job to the worker when we know what the outcome will be.