### PR TITLE
test: add CI-only tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,9 +26,51 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
+      - uses: volta-cli/action@v1.7.0
+      - name: Install multiple Node versions
+        if: runner.os != 'Windows'
+        run: |
+          volta install node@10
+          echo "NODE_10=$(volta which node)" >> $GITHUB_ENV
+          echo "NODE_10_VERSION=$(node --version)" >> $GITHUB_ENV
+          volta install node@latest
+          echo "NODE_LATEST=$(volta which node)" >> $GITHUB_ENV
+          echo "NODE_LATEST_VERSION=$(node --version)" >> $GITHUB_ENV
+          volta install node@16
+          echo "NODE_DEFAULT=$(volta which node)" >> $GITHUB_ENV
+          echo "NODE_DEFAULT_VERSION=$(node --version)" >> $GITHUB_ENV
+      - name: Install multiple Node versions (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          volta install node@10
+          echo "NODE_10=$(volta which node)" >> $env:GITHUB_ENV
+          echo "NODE_10_VERSION=$(node --version)" >> $env:GITHUB_ENV
+          volta install node@latest
+          echo "NODE_LATEST=$(volta which node)" >> $env:GITHUB_ENV
+          echo "NODE_LATEST_VERSION=$(node --version)" >> $env:GITHUB_ENV
+          volta install node@16
+          echo "NODE_DEFAULT=$(volta which node)" >> $env:GITHUB_ENV
+          echo "NODE_DEFAULT_VERSION=$(node --version)" >> $env:GITHUB_ENV
+      - name: Setup dummy ESLint projects
+        run: |
+          mkdir ~/with-eslint-6 && cd ~/with-eslint-6
+          npm init --yes
+          npm install eslint@6
+          cd ..
+
+          mkdir ~/with-eslint-7 && cd ~/with-eslint-7
+          npm init --yes
+          npm install eslint@7
+          cd ..
+
+          mkdir ~/with-eslint-latest && cd ~/with-eslint-latest
+          npm init --yes
+          npm install eslint@latest
+          cd ..
       - name: Install dependencies
         run: |
           apm install
+          apm install linter-eslint
           # ./node_modules/.bin/atom-package-deps .
 
       - name: Run tests 👩🏾‍💻

--- a/lib/job-manager.js
+++ b/lib/job-manager.js
@@ -105,9 +105,7 @@ class JobManager {
         .on('data', this.receiveError.bind(this));
     });
 
-    let nullWorkerPromise = () => {
-      this._workerPromise = null;
-    };
+    let nullWorkerPromise = () => this._workerPromise = null;
 
     this._workerPromise = promise;
     this._workerPromise
@@ -119,7 +117,8 @@ class JobManager {
 
   async suspend () {
     console.debug('Suspending worker');
-    // To prevent async chaos, we should refrain from killing a worker that we're in the process of
+    // To prevent async chaos, we should refrain from killing a worker that
+    // we're in the process of creating.
     let promise = this._workerPromise || Promise.resolve();
     this._killingWorkerPromise = promise.then(() => {
       let worker = this.worker;

--- a/lib/job-manager.js
+++ b/lib/job-manager.js
@@ -57,7 +57,11 @@ class JobManager {
 
     let nodeBin = Config.get('nodeBin');
     console.debug('JobManager creating worker at:', nodeBin);
-    this.killWorker();
+
+    // TODO: Figure out if this can even happen anymore.
+    if (this.worker) {
+      this.killWorker(this.worker);
+    }
 
     // We choose to do a sync test here because this method is much easier to
     // reason about without an `await` keyword introducing side effects.
@@ -99,32 +103,37 @@ class JobManager {
       this.worker.stderr
         .pipe(ndjson.parse())
         .on('data', this.receiveError.bind(this));
-
-      this.worker.on('close', () => {
-        if (this.worker.killed === false) {
-          this.createWorker();
-        }
-      });
     });
+
+    let nullWorkerPromise = () => {
+      this._workerPromise = null;
+    };
 
     this._workerPromise = promise;
     this._workerPromise
-      .then(() => this._workerPromise = null)
-      .catch(() => this._workerPromise = null);
+      .then(nullWorkerPromise)
+      .catch(nullWorkerPromise);
 
     return promise;
   }
 
-  suspend () {
-    console.warn('Suspending worker');
-    this.killWorker();
-    this.worker = null;
+  async suspend () {
+    console.debug('Suspending worker');
+    // To prevent async chaos, we should refrain from killing a worker that we're in the process of
+    let promise = this._workerPromise || Promise.resolve();
+    this._killingWorkerPromise = promise.then(() => {
+      let worker = this.worker;
+      this.worker = null;
+      this.killWorker(worker);
+      this._killingWorkerPromise = null;
+    });
+    return this._killingWorkerPromise;
   }
 
-  killWorker () {
-    if (!this.worker || this.worker.exitCode) { return; }
-    this.worker.removeAllListeners();
-    this.worker.kill();
+  killWorker (worker) {
+    if (!worker || worker.exitCode) { return; }
+    worker.removeAllListeners();
+    worker.kill();
   }
 
   ensureWorker () {
@@ -170,8 +179,12 @@ class JobManager {
   }
 
   async send (bundle) {
+    if (this._killingWorkerPromise) {
+      console.debug('Waiting for worker to be killed');
+      await this._killingWorkerPromise;
+    }
     if (!this.worker) {
-      console.warn('Creating worker');
+      console.debug('Creating worker');
       await this.createWorker();
     }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -55,7 +55,7 @@ export default {
   },
 
   isLegacyPackagePresent () {
-    return ('linter-eslint' in atom.packages.activePackages);
+    return atom.packages.isPackageActive('linter-eslint');
   },
 
   async activate () {
@@ -132,11 +132,11 @@ export default {
 
           if (config.nodeBin !== prevConfig.nodeBin) {
             this.notified.invalidNodeBin = false;
+            this.jobManager.suspend();
             NodePathTester
               .test(config.nodeBin)
               .then((version) => {
-                console.log(`Switched Node to version:`, version);
-                this.jobManager.suspend();
+                console.info(`Switched Node to version:`, version);
               })
               .catch(() => {
                 this.sleep();
@@ -249,8 +249,8 @@ export default {
   // Show a bunch of stuff to the user that can help them figure out why the
   // package isn't behaving the way they think it ought to, or else give them
   // something to copy and paste into a new issue.
-  async debugJob () {
-    const textEditor = atom.workspace.getActiveTextEditor();
+  async debugJob (editor = null) {
+    const textEditor = editor || atom.workspace.getActiveTextEditor();
     let filePath = 'unknown', editorScopes = ['unknown'];
     if (atom.workspace.isTextEditor(textEditor)) {
       filePath = textEditor.getPath();
@@ -328,7 +328,7 @@ export default {
       }
     } catch (error) {
       atom.notifications.addError(`${error}`, { dismissable: true });
-      return;
+      return {};
     }
 
     let whichPackageWillLint;
@@ -339,6 +339,7 @@ export default {
     } else {
       whichPackageWillLint = 'linter-eslint-node';
     }
+    debug.whichPackageWillLint = whichPackageWillLint;
 
     let debugMessage = [
       `Atom version: ${debug.atomVersion}`,

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -16,7 +16,6 @@ const MINIMUM_ESLINT_VERSION = '7.0.0';
 const PATHS_CACHE = new Map();
 const ESLINT_CACHE = new Map();
 
-// TODO: There must be some cases where this logic is too naive, right?
 function descendsFrom (filePath, projectPath) {
   if (typeof filePath !== 'string') { return false; }
   return filePath.startsWith(projectPath.endsWith(Path.sep) ? projectPath : `${projectPath}${Path.sep}`);
@@ -414,7 +413,7 @@ async function processMessage (bundle) {
       return;
     }
     error.key = key;
-    error.error = 'Unknown error';
+    error.error = error.message || 'Unknown error';
     emitError(
       JSON.stringify(error, Object.getOwnPropertyNames(error))
     );

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -2,5 +2,8 @@ module.exports = {
   env: {
     jasmine: true,
     atomtest: true
+  },
+  globals: {
+    pass: 'readonly'
   }
 };

--- a/spec/fixtures/ci/package-interaction/.eslintrc
+++ b/spec/fixtures/ci/package-interaction/.eslintrc
@@ -1,0 +1,6 @@
+{
+  root: true,
+  rules: {
+    "no-unused-vars": "error"
+  }
+}

--- a/spec/fixtures/ci/package-interaction/index.js
+++ b/spec/fixtures/ci/package-interaction/index.js
@@ -1,0 +1,4 @@
+
+function unusedFunction () {
+  // no-op
+}

--- a/spec/linter-eslint-node-spec.js
+++ b/spec/linter-eslint-node-spec.js
@@ -328,36 +328,6 @@ describe('The eslint provider for Linter', () => {
     });
   });
 
-  // TODO:
-  // describe('when an eslint cache file is present', () => {
-  //   let editor;
-  //   let tempDir;
-  //
-  //   beforeEach(async () => {
-  //     // Copy the file to a temporary folder
-  //     const tempFixturePath = await copyFileToTempDir(paths.fix);
-  //     editor = await atom.workspace.open(tempFixturePath);
-  //     tempDir = path.dirname(tempFixturePath);
-  //     // Copy the config to the same temporary directory
-  //     await copyFileToDir(paths.config, tempDir);
-  //   });
-  //
-  //   afterEach(() => {
-  //     // Remove the temporary directory
-  //     rimraf.sync(tempDir);
-  //   });
-  //
-  //   it('does not delete the cache file when performing fixes', async () => {
-  //     const tempCacheFile = await copyFileToDir(paths.cache, tempDir);
-  //     const checkCachefileExists = () => {
-  //       fs.statSync(tempCacheFile);
-  //     };
-  //     expect(checkCachefileExists).not.toThrow();
-  //     await makeFixes(editor);
-  //     expect(checkCachefileExists).not.toThrow();
-  //   });
-  // });
-
   describe('Ignores specified rules when editing', () => {
     let expectedPath;
 
@@ -527,7 +497,6 @@ describe('The eslint provider for Linter', () => {
     expect(messages[0].location.position).toEqual([[5, 2], [6, 15]]);
   });
 
-  // TODO:
   describe('when setting `disableWhenNoEslintConfig` is false', () => {
     let editor;
     let tempFilePath;
@@ -558,7 +527,6 @@ describe('The eslint provider for Linter', () => {
     });
   });
 
-  // TODO:
   describe('when `disableWhenNoEslintConfig` is true', () => {
     let editor;
     let tempFixtureDir;
@@ -580,95 +548,6 @@ describe('The eslint provider for Linter', () => {
       expect(messages.length).toBe(0);
     });
   });
-
-  // TODO:
-  // describe('lets ESLint handle configuration', () => {
-  //   it('works when the cache fails', async () => {
-  //     // Ensure the cache is enabled, since we will be taking advantage of
-  //     // a failing in it's operation
-  //     atom.config.set('linter-eslint-node.advanced.disableFSCache', false);
-  //     const fooPath = path.join(paths.badCache, 'temp', 'foo.js');
-  //     const newConfigPath = path.join(paths.badCache, 'temp', '.eslintrc.js');
-  //     const editor = await atom.workspace.open(fooPath);
-  //     function undefMsg(varName) {
-  //       return `[no-undef] '${varName}' is not defined.`;
-  //     }
-  //     // TODO: const expectedUrl = 'https://eslint.org/docs/rules/no-undef';
-  //
-  //     // Trigger a first lint to warm up the cache with the first config result
-  //     let messages = await lint(editor);
-  //     expect(messages.length).toBe(2);
-  //     expect(messages[0].severity).toBe('error');
-  //     expect(messages[0].excerpt).toBe(undefMsg('console'));
-  //     // TODO: expect(messages[0].url).toBe(expectedUrl);
-  //     expect(messages[0].location.file).toBe(fooPath);
-  //     expect(messages[0].location.position).toEqual([[1, 2], [1, 9]]);
-  //     expect(messages[1].severity).toBe('error');
-  //     expect(messages[1].excerpt).toBe(undefMsg('bar'));
-  //     // TODO: expect(messages[1].url).toBe(expectedUrl);
-  //     expect(messages[1].location.file).toBe(fooPath);
-  //     expect(messages[1].location.position).toEqual([[1, 14], [1, 17]]);
-  //
-  //     // Write the new configuration file
-  //     const newConfig = {
-  //       env: {
-  //         browser: true,
-  //       },
-  //     };
-  //     let configContents = `module.exports = ${JSON.stringify(newConfig, null, 2)}\n`;
-  //     fs.writeFileSync(newConfigPath, configContents);
-  //
-  //     // Lint again, ESLint should recognise the new configuration
-  //     // The cached config results are still pointing at the _parent_ file. ESLint
-  //     // would partially handle this situation if the config file was specified
-  //     // from the cache.
-  //     messages = await lint(editor);
-  //     expect(messages.length).toBe(1);
-  //     expect(messages[0].severity).toBe('error');
-  //     expect(messages[0].excerpt).toBe(undefMsg('bar'));
-  //     // TODO: expect(messages[0].url).toBe(expectedUrl);
-  //     expect(messages[0].location.file).toBe(fooPath);
-  //     expect(messages[0].location.position).toEqual([[1, 14], [1, 17]]);
-  //
-  //     // Update the configuration
-  //     newConfig.rules = {
-  //       'no-undef': 'off',
-  //     };
-  //     configContents = `module.exports = ${JSON.stringify(newConfig, null, 2)}\n`;
-  //     fs.writeFileSync(newConfigPath, configContents);
-  //
-  //     // Lint again, if the cache was specifying the file ESLint at this point
-  //     // would fail to update the configuration fully, and would still report a
-  //     // no-undef error.
-  //     messages = await lint(editor);
-  //     expect(messages.length).toBe(0);
-  //
-  //     // Delete the temporary configuration file
-  //     fs.unlinkSync(newConfigPath);
-  //   });
-  // });
-
-  // TODO:
-  // describe('works with HTML files', () => {
-  //   const embeddedScope = 'source.js.embedded.html';
-  //   const scopes = linterProvider.grammarScopes;
-  //
-  //   it('adds the HTML scope when the setting is enabled', () => {
-  //     expect(scopes.includes(embeddedScope)).toBe(false);
-  //     atom.config.set('linter-eslint-node.lintHtmlFiles', true);
-  //     expect(scopes.includes(embeddedScope)).toBe(true);
-  //     atom.config.set('linter-eslint-node.lintHtmlFiles', false);
-  //     expect(scopes.includes(embeddedScope)).toBe(false);
-  //   });
-  //
-  //   it('keeps the HTML scope with custom scopes', () => {
-  //     expect(scopes.includes(embeddedScope)).toBe(false);
-  //     atom.config.set('linter-eslint-node.lintHtmlFiles', true);
-  //     expect(scopes.includes(embeddedScope)).toBe(true);
-  //     atom.config.set('linter-eslint-node.scopes', ['foo.bar']);
-  //     expect(scopes.includes(embeddedScope)).toBe(true);
-  //   });
-  // });
 
   describe('handles the Show Rule ID in Messages option', () => {
     const expectedUrlRegEx = /https[\S]+eslint-plugin-import[\S]+no-unresolved.md/;

--- a/spec/node-bin-spec.js
+++ b/spec/node-bin-spec.js
@@ -1,0 +1,169 @@
+'use babel';
+import * as Path from 'path';
+import * as FS from 'fs';
+import {
+  copyFileToDir,
+  openAndSetProjectDir,
+  wait
+} from './helpers';
+import rimraf from 'rimraf';
+import linterEslintNode from '../lib/main';
+
+const root = Path.normalize(process.env.HOME);
+const paths = {
+  eslint6: Path.join(root, 'with-eslint-6'),
+  eslint7: Path.join(root, 'with-eslint-7'),
+  eslintLatest: Path.join(root, 'with-eslint-latest')
+};
+
+const fixtureRoot = Path.join(__dirname, 'fixtures', 'ci', 'package-interaction');
+
+async function writeProjectConfig (projectPath, config) {
+  let overrideFile = Path.join(projectPath, '.linter-eslint');
+  let text = JSON.stringify(config, null, 2);
+  FS.writeFileSync(overrideFile, text);
+  await wait(1000);
+}
+
+async function copyFilesIntoProject (projectPath) {
+  let files = [
+    Path.join(fixtureRoot, '.eslintrc'),
+    Path.join(fixtureRoot, 'index.js')
+  ];
+  for (let file of files) {
+    await copyFileToDir(file, projectPath);
+  }
+}
+
+async function deleteFilesFromProject (projectPath) {
+  let files = [
+    Path.join(projectPath, '.eslintrc'),
+    Path.join(projectPath, 'index.js'),
+    Path.join(projectPath, '.linter-eslint')
+  ];
+  for (let file of files) {
+    await rimraf.sync(file);
+  }
+}
+
+function expectVersionMatch (expected, actual) {
+  expected = expected.replace(/\s/g, '');
+  actual = actual.replace(/\s/g, '');
+  expect(expected).toBe(actual);
+}
+
+if (process.env.CI) {
+  describe('Node binary config', () => {
+    const linterProvider = linterEslintNode.provideLinter();
+    const debugJob = linterEslintNode.debugJob.bind(linterEslintNode);
+    const { lint } = linterProvider;
+
+    beforeEach(async () => {
+      atom.config.set('linter-eslint-node.nodeBin', process.env.NODE_DEFAULT);
+
+      atom.packages.triggerDeferredActivationHooks();
+      atom.packages.triggerActivationHook('core:loaded-shell-environment');
+
+      await atom.packages.activatePackage('language-javascript');
+      await atom.packages.activatePackage('linter-eslint-node');
+    });
+
+    describe('with default nodeBin', () => {
+      let editor;
+      beforeEach(async () => {
+        await copyFilesIntoProject(paths.eslintLatest);
+        editor = await openAndSetProjectDir(
+          Path.join(paths.eslintLatest, 'index.js'),
+          paths.eslintLatest
+        );
+      });
+
+      afterEach(async () => {
+        await deleteFilesFromProject(paths.eslintLatest);
+      });
+
+      it('lints correctly', async () => {
+        let results = await lint(editor);
+        expect(results.length).toBe(1);
+      });
+
+      it('reports the correct version of Node', async () => {
+        let debug = await debugJob(editor);
+        expectVersionMatch(
+          debug.nodeVersion,
+          process.env.NODE_DEFAULT_VERSION
+        );
+      });
+    });
+
+    describe('with project override', () => {
+      let editor;
+
+      beforeEach(async () => {
+        await copyFilesIntoProject(paths.eslintLatest);
+        editor = await openAndSetProjectDir(
+          Path.join(paths.eslintLatest, 'index.js'),
+          paths.eslintLatest
+        );
+        await writeProjectConfig(paths.eslintLatest, {
+          nodeBin: process.env.NODE_LATEST
+        });
+      });
+
+      afterEach(async () => {
+        await deleteFilesFromProject(paths.eslintLatest);
+      });
+
+      it('lints correctly and using the right version of Node', async () => {
+        let results = await lint(editor);
+        expect(results.length).toBe(1);
+
+        let debug = await debugJob(editor);
+        expectVersionMatch(
+          debug.nodeVersion,
+          process.env.NODE_LATEST_VERSION
+        );
+      });
+    });
+
+    describe('with config change after activation', () => {
+      let editor;
+
+      beforeEach(async () => {
+        await copyFilesIntoProject(paths.eslintLatest);
+        editor = await openAndSetProjectDir(
+          Path.join(paths.eslintLatest, 'index.js'),
+          paths.eslintLatest
+        );
+      });
+
+      afterEach(async () => {
+        await deleteFilesFromProject(paths.eslintLatest);
+      });
+
+      it('lints correctly both before and after the version change', async () => {
+        let debug = await debugJob(editor);
+        expectVersionMatch(
+          debug.nodeVersion,
+          process.env.NODE_DEFAULT_VERSION
+        );
+
+        let results = await lint(editor);
+        expect(results.length).toBe(1);
+
+        atom.config.set('linter-eslint-node.nodeBin', process.env.NODE_LATEST);
+        wait(1000);
+
+        debug = await debugJob(editor);
+        expectVersionMatch(
+          debug.nodeVersion,
+          process.env.NODE_LATEST_VERSION
+        );
+
+        results = await lint(editor);
+        expect(results.length).toBe(1);
+      });
+
+    });
+  });
+}

--- a/spec/node-path-tester-spec.js
+++ b/spec/node-path-tester-spec.js
@@ -1,5 +1,4 @@
 'use babel';
-/* global pass */
 
 import NodePathTester from '../lib/node-path-tester';
 

--- a/spec/package-interaction-spec.js
+++ b/spec/package-interaction-spec.js
@@ -1,0 +1,177 @@
+'use babel';
+import * as Path from 'path';
+import * as FS from 'fs';
+import {
+  copyFileToDir,
+  getNotification,
+  openAndSetProjectDir,
+  // wait
+} from './helpers';
+import rimraf from 'rimraf';
+import linterEslintNode from '../lib/main';
+
+const root = Path.normalize(process.env.HOME);
+const paths = {
+  eslint6: Path.join(root, 'with-eslint-6'),
+  eslint7: Path.join(root, 'with-eslint-7'),
+  eslintLatest: Path.join(root, 'with-eslint-latest')
+};
+
+const packagesRoot = Path.join(root, '.atom', 'packages');
+const fixtureRoot = Path.join(__dirname, 'fixtures', 'ci', 'package-interaction');
+
+async function expectNoNotification (fn) {
+  let notificationPromise = getNotification();
+  await fn();
+  let notification = await notificationPromise;
+  expect(notification).toBe(undefined);
+}
+
+async function copyFilesIntoProject (projectPath) {
+  let files = [
+    Path.join(fixtureRoot, '.eslintrc'),
+    Path.join(fixtureRoot, 'index.js')
+  ];
+  for (let file of files) {
+    await copyFileToDir(file, projectPath);
+  }
+}
+
+async function deleteFilesFromProject (projectPath) {
+  let files = [
+    Path.join(projectPath, '.eslintrc'),
+    Path.join(projectPath, 'index.js')
+  ];
+  for (let file of files) {
+    await rimraf.sync(file);
+  }
+}
+
+if (process.env.CI) {
+  describe('Package interaction', () => {
+    const linterProvider = linterEslintNode.provideLinter();
+    const { lint } = linterProvider;
+
+    beforeEach(async () => {
+      atom.config.set('linter-eslint-node.nodeBin', process.env.NODE_DEFAULT);
+
+      atom.packages.triggerDeferredActivationHooks();
+      atom.packages.triggerActivationHook('core:loaded-shell-environment');
+
+      await atom.packages.loadPackage(
+        Path.join(packagesRoot, 'linter-eslint')
+      );
+
+      await atom.packages.activatePackage('language-javascript');
+      await atom.packages.activatePackage('linter-eslint-node');
+    });
+
+    describe('With linter-eslint enabled', () => {
+      beforeEach(async () => {
+        await atom.packages.activatePackage('linter-eslint');
+      });
+
+      it('should do nothing when opening an ESLint@6 project', async () => {
+        await copyFilesIntoProject(paths.eslint6);
+        console.log('checking for existence of index.js:');
+        expect(FS.existsSync(Path.join(paths.eslint6, 'index.js'))).toBe(true);
+        let editor = await openAndSetProjectDir(
+          Path.join(paths.eslint6, 'index.js'),
+          paths.eslint6
+        );
+
+        await expectNoNotification(async () => {
+          let results = await lint(editor);
+          expect(results).toBe(null);
+        });
+
+        await deleteFilesFromProject(paths.eslint6);
+      });
+
+      it('should do nothing when opening an ESLint@7 project', async () => {
+        await copyFilesIntoProject(paths.eslint7);
+        let editor = await openAndSetProjectDir(
+          Path.join(paths.eslint7, 'index.js'),
+          paths.eslint7
+        );
+
+        await expectNoNotification(async () => {
+          let results = await lint(editor);
+          expect(results).toBe(null);
+        });
+
+        await deleteFilesFromProject(paths.eslint7);
+      });
+
+      it('should lint when opening an ESLint@8 project', async () => {
+        await copyFilesIntoProject(paths.eslintLatest);
+        let editor = await openAndSetProjectDir(
+          Path.join(paths.eslintLatest, 'index.js'),
+          paths.eslintLatest
+        );
+
+        await expectNoNotification(async () => {
+          let results = await lint(editor);
+          expect(results.length).toBe(1);
+        });
+        await deleteFilesFromProject(paths.eslintLatest);
+      });
+    });
+
+    describe('With linter-eslint disabled', () => {
+      beforeEach(async () => {
+        await atom.packages.deactivatePackage('linter-eslint');
+      });
+
+      it('should prompt to install linter-eslint when opening an ESLint@6 project', async () => {
+        await copyFilesIntoProject(paths.eslint6);
+        let editor = await openAndSetProjectDir(
+          Path.join(paths.eslint6, 'index.js'),
+          paths.eslint6
+        );
+
+        const notificationPromise = getNotification();
+        let results = await lint(editor);
+        expect(results).toBe(null);
+        let notification = await notificationPromise;
+
+        if (!notification) {
+          fail('Did not get notification');
+        } else {
+          expect(notification.getMessage()).toBe('linter-eslint-node: Incompatible ESLint');
+        }
+        await deleteFilesFromProject(paths.eslint6);
+      });
+
+      it('should lint when opening an ESLint@7 project', async () => {
+        await copyFilesIntoProject(paths.eslint7);
+        let editor = await openAndSetProjectDir(
+          Path.join(paths.eslint7, 'index.js'),
+          paths.eslint7
+        );
+        expect(atom.packages.isPackageActive('linter-eslint')).toBe(false);
+
+        await expectNoNotification(async () => {
+          let results = await lint(editor);
+          expect(results.length).toBe(1);
+        });
+
+        await deleteFilesFromProject(paths.eslint7);
+      });
+
+      it('should lint when opening an ESLint@8 project', async () => {
+        await copyFilesIntoProject(paths.eslintLatest);
+        let editor = await openAndSetProjectDir(
+          Path.join(paths.eslintLatest, 'index.js'),
+          paths.eslintLatest
+        );
+
+        await expectNoNotification(async () => {
+          let results = await lint(editor);
+          expect(results.length).toBe(1);
+        });
+        await deleteFilesFromProject(paths.eslintLatest);
+      });
+    });
+  });
+}


### PR DESCRIPTION
This wasn't as hard as I feared it would be.

Got most of what I wanted from #7. Only outstanding thing is what to do when faced with a version of Node that's too old, but I'm not exactly sure what the behavior should be there. If the configured Node version and the project's ESLint version fail to interoperate, that could manifest in many different ways, so until it becomes a problem in the real world I think I'll punt on it.