### PR TITLE
fix: check for existence of `docs` before accessing `url`

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -289,7 +289,7 @@ function formatResults (files, rules, config, { isModified, key, isFixJob, lintM
         },
         fix: message.fix,
         excerpt: `${message.message}${idTag}`,
-        url: rule ? rule.docs.url : undefined
+        url: rule && rule.docs ? rule.docs.url : undefined
       });
     }
   }


### PR DESCRIPTION
Encountered a rule without `docs` (was `@babel/semi` rule FWIW), so adding a guard.