### PR TITLE
chore!: Make eslint@8 the minimum supported version for this package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The `linter` package will be installed for you if it’s not already present in 
 
 Two reasons:
 
-1. After it was deprecated in v8, the `CLIEngine` class that `linter-eslint` relied upon was removed from ESLint in v8. Its replacement removed a few methods that supported some of `linter-eslint`’s features, making it impossible to abstract away the difference between the two, or to deliver an experience that’s consistent across ESLint versions.
+1. After it was deprecated in v7, the `CLIEngine` class that `linter-eslint` relied upon was removed from ESLint in v8. Its replacement removed a few methods that supported some of `linter-eslint`’s features, making it impossible to abstract away the difference between the two, or to deliver an experience that’s consistent across ESLint versions.
 
 2. As the Node world slowly migrates away from CommonJS and toward [ECMAScript modules][], certain high-profile ESLint plugins now offer native ESM versions. This is not a problem for any recent version of Node, but it is a problem for `linter-eslint`’s practice of linting within a worker script using _Atom’s_ version of Node, which is too old to support ESM and is unlikely to be updated in the near future. The solution to this problem is to switch to a “bring-your-own-Node” model that runs the worker script inside the same version of Node that your project itself uses.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # linter-eslint-node package
 
-A “bring-your-own-Node” linter for newer versions of ESLint: v7 and above.
+A “bring-your-own-Node” linter for newer versions of ESLint: v8 and above.
 
 ## Installation
 
@@ -15,19 +15,19 @@ The `linter` package will be installed for you if it’s not already present in 
 
 Two reasons:
 
-1. After it was deprecated in v7, the `CLIEngine` class that `linter-eslint` relied upon was removed from ESLint in v8. Its replacement removed a few methods that supported some of `linter-eslint`’s features, making it impossible to abstract away the difference between the two, or to deliver an experience that’s consistent across ESLint versions.
+1. After it was deprecated in v8, the `CLIEngine` class that `linter-eslint` relied upon was removed from ESLint in v8. Its replacement removed a few methods that supported some of `linter-eslint`’s features, making it impossible to abstract away the difference between the two, or to deliver an experience that’s consistent across ESLint versions.
 
 2. As the Node world slowly migrates away from CommonJS and toward [ECMAScript modules][], certain high-profile ESLint plugins now offer native ESM versions. This is not a problem for any recent version of Node, but it is a problem for `linter-eslint`’s practice of linting within a worker script using _Atom’s_ version of Node, which is too old to support ESM and is unlikely to be updated in the near future. The solution to this problem is to switch to a “bring-your-own-Node” model that runs the worker script inside the same version of Node that your project itself uses.
 
 ## Should I uninstall linter-eslint?
 
-Depends. The `linter-eslint` package supports **ESLint up through and including v7**. This new package supports **ESLint v7 and greater**. The overlap in v7 is because that’s the one major version where both interfaces, `CLIEngine` and `ESLint`, are available.
+Depends. The `linter-eslint` package supports **ESLint up through and including v7**. This new package supports **ESLint v8 and greater**.
 
-If _all_ your projects use ESLint `>=7.0.0`, you can keep this package and uninstall `linter-eslint`. If _any_ of your projects use an older ESLint, you should keep `linter-eslint` installed alongside this package. **This package can coexist with `linter-eslint`; they won’t get in each other’s way.**
+If _all_ your projects use ESLint `>=8.0.0`, you can keep this package and uninstall `linter-eslint`. If _any_ of your projects use an older ESLint, you should keep `linter-eslint` installed alongside this package.
 
-Since they can both lint when ESLint 7.x is present, they have to coordinate who does the linting when both packages are installed. **If `linter-eslint` is installed, this package will not perform linting in ESLint 7.x environments** — only 8.x or greater. If only this package is installed, it will lint with any version of ESLint it supports.
+If only this package is installed, it will lint with any version of ESLint it supports.
 
-When `linter-eslint` is not installed and this package detects an ESLint version too old for it to support, it will show a notification and invite you to install `linter-eslint`. This behavior can be disabled in package settings.
+When `linter-eslint` is not installed and this package detects an ESLint version too old for it to support, it will show a notification and invite you to install `linter-eslint`. This behaviour can be disabled in package settings.
 
 ## How do I “bring my own Node”?
 
@@ -89,7 +89,7 @@ Keep in mind you’ll have to update this setting whenever you update the versio
 
 ## Which ESLint version will this package use?
 
-`linter-eslint-node` will look for a version of ESLint local to your project, as long as it’s at least v7.0.0. Ideally, this would be installed into a `node_modules` folder in the project root, but it’ll find anything in `module.paths`.
+`linter-eslint-node` will look for a version of ESLint local to your project, as long as it’s at least v8.0.0. Ideally, this would be installed into a `node_modules` folder in the project root, but it’ll find anything in `module.paths`.
 
 If you can run `node -e "require('eslint')"` from your project root and not get an error, then `linter-eslint-node` should find your copy of ESLint just fine.
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -65,10 +65,9 @@ export default {
 
     // “Inactive” is the mode we enter when we think a project won’t be doing
     // much, or any, linting. Examples include (a) no ESLint in this project,
-    // (b) too-old ESLint in this project, (c) v7 ESLint when we’re deferring
-    // to the legacy package. Option A will be the most common, as it would
-    // also apply to all non-JavaScript projects, for which it’s silly and
-    // wasteful to keep a worker process around.
+    // (b) too-old ESLint in this project. Option A will be the most common,
+    // as it would also apply to all non-JavaScript projects, for which it’s
+    // silly and wasteful to keep a worker process around.
     //
     // If we see evidence of any of these situations, we should put ourselves
     // to sleep via `this.sleep`. This kills our worker process, and it also
@@ -487,13 +486,6 @@ export default {
       return null;
     }
 
-    if (err.type && err.type === 'version-overlap') {
-      // This is an easy one: we don't need to lint this file because
-      // `linter-eslint` is present and can handle it. Do nothing.
-      this.sleep();
-      return null;
-    }
-
     if (err.type && err.type === 'incompatible-version') {
       // This ESLint is too old. If the user also has `linter-eslint`
       // installed, we don't need to say or do anything; we can just silently
@@ -508,7 +500,7 @@ export default {
         return null;
       } else {
         // eslint-disable-next-line max-len
-        let description = `The ESLint module in this project is of version ${err.version}; linter-eslint-node requires a version of 7.0.0 or greater. You can install the legacy \`linter-eslint\` package if you don’t want to upgrade ESLint.\n\nYou can disable this message in package settings.`;
+        let description = `The ESLint module in this project is of version ${err.version}; linter-eslint-node requires a version of 8.0.0 or greater. You can install the legacy \`linter-eslint\` package if you don’t want to upgrade ESLint.\n\nYou can disable this message in package settings.`;
         atom.notifications.addWarning(
           `linter-eslint-node: Incompatible ESLint`,
           {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -11,7 +11,7 @@ const { createRequire } = require('module');
 const compareVersions = require('compare-versions');
 const ndjson = require('ndjson');
 
-const MINIMUM_ESLINT_VERSION = '7.0.0';
+const MINIMUM_ESLINT_VERSION = '8.0.0';
 
 const PATHS_CACHE = new Map();
 const ESLINT_CACHE = new Map();
@@ -51,16 +51,6 @@ class IncompatibleVersionError extends Error {
     let message = `This project uses ESLint version ${version}; linter-eslint-node requires a minimum of ${MINIMUM_ESLINT_VERSION}.`;
     super(message);
     this.name = 'IncompatibleVersionError';
-    this.version = version;
-  }
-}
-
-class VersionOverlapError extends Error {
-  constructor (version) {
-    // eslint-disable-next-line max-len
-    let message = `This version of ESLint is compatible with linter-eslint, which is present in this installation of Atom.`;
-    super(message);
-    this.name = 'VersionOverlapError';
     this.version = version;
   }
 }
@@ -195,11 +185,6 @@ function getESLint (filePath, config, { isDebug, legacyPackagePresent, projectPa
     if (compareVersions(cached.eslintVersion, MINIMUM_ESLINT_VERSION) < 1) {
       // Unsupported version.
       throw new IncompatibleVersionError(cached.eslintVersion);
-    } else if ((compareVersions(cached.eslintVersion, '8.0.0') < 1) && legacyPackagePresent) {
-      // We're dealing with version 7 of ESLint. The legacy `linter-eslint`
-      // package is present and capable of linting with this version, so we
-      // should halt instead of trying to lint everything twice.
-      throw new VersionOverlapError(cached.eslintVersion);
     }
   }
 
@@ -345,13 +330,6 @@ async function processMessage (bundle) {
         error: err.message,
         version: err.version,
         type: 'incompatible-version'
-      });
-    } else if (err instanceof VersionOverlapError) {
-      emit({
-        key,
-        error: err.message,
-        version: err.version,
-        type: 'version-overlap'
       });
     } else {
       log(`Error: ${err.message}`);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -123,7 +123,7 @@ function resolveESLint (filePath) {
   }
 }
 
-function getESLint (filePath, config, { isDebug, legacyPackagePresent, projectPath }) {
+function getESLint (filePath, config, { isDebug, projectPath }) {
   let { advanced: { useCache } } = config;
   // If two files share a `cwd`, we can reuse any `ESLint` instance that was
   // created for one to lint the other. The `cwd` is almost always the project

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linter-eslint-node",
   "main": "./lib/main",
   "version": "1.0.6",
-  "description": "Lint JavaScript on the fly, using ESLint (v7 or greater)",
+  "description": "Lint JavaScript on the fly, using ESLint (v8 or greater)",
   "keywords": [
     "linter-eslint",
     "eslint"

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -11,14 +11,18 @@ import { tmpdir } from 'os';
  * @return {Promise<string>}        path of the file in copy destination
  */
 export function copyFileToDir(fileToCopyPath, destinationDir, newFileName = null) {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const destinationPath = path.join(
       destinationDir,
       newFileName || path.basename(fileToCopyPath)
     );
+    const rs = fs.createReadStream(fileToCopyPath);
     const ws = fs.createWriteStream(destinationPath);
+
     ws.on('close', () => resolve(destinationPath));
-    fs.createReadStream(fileToCopyPath).pipe(ws);
+    ws.on('error', (error) => reject(error));
+
+    rs.pipe(ws);
   });
 }
 

--- a/spec/package-interaction-spec.js
+++ b/spec/package-interaction-spec.js
@@ -143,18 +143,23 @@ if (process.env.CI) {
         await deleteFilesFromProject(paths.eslint6);
       });
 
-      it('should lint when opening an ESLint@7 project', async () => {
+      it('should prompt to install linter-eslint when opening an ESLint@7 project', async () => {
         await copyFilesIntoProject(paths.eslint7);
         let editor = await openAndSetProjectDir(
           Path.join(paths.eslint7, 'index.js'),
           paths.eslint7
         );
-        expect(atom.packages.isPackageActive('linter-eslint')).toBe(false);
 
-        await expectNoNotification(async () => {
-          let results = await lint(editor);
-          expect(results.length).toBe(1);
-        });
+        const notificationPromise = getNotification();
+        let results = await lint(editor);
+        expect(results).toBe(null);
+        let notification = await notificationPromise;
+
+        if (!notification) {
+          fail('Did not get notification');
+        } else {
+          expect(notification.getMessage()).toBe('linter-eslint-node: Incompatible ESLint');
+        }
 
         await deleteFilesFromProject(paths.eslint7);
       });


### PR DESCRIPTION
See #25 #27

This simply bumps the lowest supported version of eslint to v8.

~TODO: Make the same change in the https://github.com/AtomLinter/linter-eslint~