### PR TITLE
fix: Clear cache properly when .eslintrc changes

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -109,10 +109,10 @@ function buildCommonConstructorOptions (config, cwd) {
 }
 
 function clearESLintCache () {
-  for (let key of PATHS_CACHE) {
+  for (let key of PATHS_CACHE.keys()) {
     PATHS_CACHE.delete(key);
   }
-  for (let key of ESLINT_CACHE) {
+  for (let key of ESLINT_CACHE.keys()) {
     ESLINT_CACHE.delete(key);
   }
 }

--- a/spec/runner.js
+++ b/spec/runner.js
@@ -1,6 +1,19 @@
 'use babel';
 
 import { createRunner } from 'atom-jasmine3-test-runner';
+import childProcess from 'child_process';
+
+if (process.env.PATH === '/usr/bin:/bin:/usr/sbin:/sbin') {
+  // If the PATH value is the default, we're probably in a GUI spec-runner
+  // window that has failed to inherit its PATH variable from the window that
+  // spawned it. This happened sporadically in Atom but is happening
+  // consistently in Pulsar. This is a quick fix.
+  let shellOutput = childProcess.execFileSync(
+    process.env.SHELL,
+    ['-i', '-c', 'echo $PATH']
+  ).toString().trim().split('\n');
+  process.env.PATH = shellOutput[shellOutput.length - 1];
+}
 
 function setDefaultSettings(namespace, settings) {
   for (const name in settings) {


### PR DESCRIPTION
This was an oversight; file it under “how did this ever work?” Rather than iterating over keys, I was iterating over the key/value array yielded by each `Map`, so deletion had no effect, because I was asking it to delete keys that did not exist.

To verify:

1. Make sure the “Use cache” setting is enabled.
2. Trigger a linter error/warning in a file in your project.
3. Change your `.eslintrc` so that it no longer cares about that rule.
4. Go back to your file and re-save.

On `main`, the linting error/warning won't go away. On this PR branch, it will.