### PR TITLE
fix: don't suspend because of non-project files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -138,7 +138,7 @@ export default {
                 console.info(`Switched Node to version:`, version);
               })
               .catch(() => {
-                this.sleep();
+                this.sleep(`Invalid node path`);
                 this.notifyAboutInvalidNodeBin();
               });
           }
@@ -150,13 +150,13 @@ export default {
           let wasInactive = this.inactive;
           this.wake();
           await this.fixJob();
-          if (wasInactive) { this.sleep(); }
+          if (wasInactive) { this.sleep(`Was previously asleep`); }
         },
         'linter-eslint-node:debug': async () => {
           let wasInactive = this.inactive;
           this.wake();
           await this.debugJob();
-          if (wasInactive) { this.sleep(); }
+          if (wasInactive) { this.sleep(`Was previously asleep`); }
         }
       }),
 
@@ -216,7 +216,8 @@ export default {
     Config.dispose();
   },
 
-  sleep () {
+  sleep (reason = null) {
+    console.debug(`Sleeping for reason:`, reason);
     this.inactive = true;
     this.jobManager.suspend();
   },
@@ -440,13 +441,20 @@ export default {
       // this session), we should do nothing here so that an invalid worker
       // behaves as though no linter is present at all.
       this.notifyAboutInvalidNodeBin();
-      this.sleep();
+      this.sleep(`Invalid node path`);
       return null;
     }
 
     if (err.type && err.type === 'config-not-found') {
       if (Config.get('disabling.disableWhenNoEslintConfig')) {
-        this.sleep();
+        let { filePath, projectPath } = err;
+        if (projectPath && projectPath.length && filePath.startsWith(projectPath)) {
+          // Failure to find an `.eslintrc` could just mean that the user is
+          // editing their `init.js` file, or any other file that just happens
+          // not to live in this project. So we've got to make sure this file
+          // lives in the project before we suspend the worker.
+          this.sleep(`No .eslintrc found`);
+        }
         return [];
       }
       if (type === 'fix') {
@@ -482,7 +490,7 @@ export default {
 
     if (err.type && err.type === 'no-project') {
       // No project means nowhere to look for an `.eslintrc`.
-      this.sleep();
+      this.sleep(`No project`);
       return null;
     }
 
@@ -495,7 +503,7 @@ export default {
       // this window has been open; no use spamming it on every lint attempt.
       let linterEslintPresent = this.isLegacyPackagePresent();
       let didNotify = this.notified.incompatibleVersion;
-      this.sleep();
+      this.sleep(`Incompatible eslint`);
       if (linterEslintPresent || didNotify || !Config.get('warnAboutOldEslint')) {
         return null;
       } else {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -390,7 +390,9 @@ async function processMessage (bundle) {
       emit({
         key,
         error: error.message,
-        type: 'config-not-found'
+        type: 'config-not-found',
+        filePath,
+        projectPath
       });
       return;
     }

--- a/spec/fixtures/no-config/test.js
+++ b/spec/fixtures/no-config/test.js
@@ -1,0 +1,3 @@
+
+// (Intentionally invalid)
+function foo () {

--- a/spec/linter-eslint-node-spec.js
+++ b/spec/linter-eslint-node-spec.js
@@ -656,7 +656,7 @@ describe('The eslint provider for Linter', () => {
       editorOutsideProject = await atom.workspace.open(tempFilePathOutside);
     });
 
-    fit("does not suspend when it can't find that file's .eslintrc", async () => {
+    it("does not suspend when it can't find that file's .eslintrc", async () => {
       expect(linterEslintNode.inactive).toBe(false);
 
       // Fails to lint because of lack of `.eslintrc`.

--- a/spec/linter-eslint-node-spec.js
+++ b/spec/linter-eslint-node-spec.js
@@ -32,7 +32,8 @@ const paths = {
   badImport: path.join(fixturesDir, 'import-resolution', 'nested', 'badImport.js'),
   fixablePlugin: path.join(fixturesDir, 'plugin-import', 'life.js'),
   eslintignoreDir: path.join(fixturesDir, 'eslintignore'),
-  eslintIgnoreKeyDir: path.join(fixturesDir, 'configs', 'eslintignorekey')
+  eslintIgnoreKeyDir: path.join(fixturesDir, 'configs', 'eslintignorekey'),
+  noConfig: path.join(fixturesDir, 'no-config', 'test.js')
 };
 
 /**
@@ -643,4 +644,27 @@ describe('The eslint provider for Linter', () => {
       ))
     ).toBe(true);
   });
+
+  describe("When a non-project file is present", () => {
+    let editorOutsideProject;
+    beforeEach(async () => {
+      const tempFilePathInside = await copyFileToTempDir(paths.bad);
+      const tempFilePathOutside = await copyFileToTempDir(paths.noConfig);
+
+      let projectDir = path.resolve(path.join(tempFilePathInside, '..'));
+      await openAndSetProjectDir(tempFilePathInside, projectDir);
+      editorOutsideProject = await atom.workspace.open(tempFilePathOutside);
+    });
+
+    fit("does not suspend when it can't find that file's .eslintrc", async () => {
+      expect(linterEslintNode.inactive).toBe(false);
+
+      // Fails to lint because of lack of `.eslintrc`.
+      const messages = await lint(editorOutsideProject);
+      expect(messages.length).toBe(0);
+
+      expect(linterEslintNode.inactive).toBe(false);
+    });
+  });
+
 });


### PR DESCRIPTION
This was a silly oversight on my part. I'd made it so that we suspend the worker and hibernate when the worker reports it failed to lint a file because of a lack of an `.eslintrc`. But that can happen when you're editing a non-project file, like your own Atom init-file.

So if the no-config error came from a non-project file, we should ignore it.

While I was at it, I made it so that we report a reason in the console whenever we suspend.